### PR TITLE
no more uppercase for h5

### DIFF
--- a/src/documents/styles/4-base/_general-styles.less
+++ b/src/documents/styles/4-base/_general-styles.less
@@ -189,7 +189,7 @@ a {
   }
 
   h4 {
-    font-weight: 500;
+    font-weight: 600;
     font-size: 18px;
     margin-bottom: 10px;
     margin-top: 30px;
@@ -200,7 +200,6 @@ a {
     font-weight: 600;
     font-size: 16px;
     color: @gray-shady-lady;
-    text-transform: uppercase;
     margin-bottom: 8px;
     margin-top: 30px;
     color: @typography-main;


### PR DESCRIPTION
Acceptance Criteria
- h5 should not be upper-case 
- make sure it is not bigger than h4 